### PR TITLE
[TASK] Suggest the usage of georgringer/news

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
 	"t3brightside/embedassets": "^1.2"
   },
   "suggest": {
+	  "georgringer/news": "Adds personnel as news authors",
 	  "t3brightside/imagelazyload": "Add an option to disable laziload in BE"
   },
   "autoload": {


### PR DESCRIPTION
With this suggestion goergringer/news should be loaded always before personnel extension if present. 
It helps to avoid problems with database updates on the tx_news_domain_model_news table see: https://docs.typo3.org/m/typo3/reference-coreapi/11.5/en-us/ExtensionArchitecture/FileStructure/ComposerJson.html#require