### PR TITLE
[BUGFIX] Remove obsolete configuration flag for news

### DIFF
--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,6 +1,4 @@
 # cat=basic/enable; type=options[Disabled=0,Enabled=1]; label=Enable as author for pages
 personnelEnableAuthors = 0
-# cat=basic/enable; type=options[Disabled=0,Enabled=1]; label=Enable as author for News
-personnelEnableNewsAuthors = 0
 # cat=basic/enable; type=options[Disabled=0,Enabled=1]; label=Enable pagination
 personnelEnablePagination = 1


### PR DESCRIPTION
The news feature has already been removed with v3.9.0, but the config flag has persisted.